### PR TITLE
[bcache] filesystems: enable upstream bcachefs support

### DIFF
--- a/components/filesystems/bcachefs.nix
+++ b/components/filesystems/bcachefs.nix
@@ -4,15 +4,12 @@
   pkgs,
   ...
 }: let
-  inherit (lib) mkEnableOption mkIf mkOverride;
+  inherit (lib) mkEnableOption mkIf;
   cfg = config.components.filesystems.bcachefs;
 in {
   options.components.filesystems.bcachefs.enable = mkEnableOption "Enable bcachefs support";
 
   config = mkIf cfg.enable {
-    # TODO: fix once bcachefs lands in upstream
-    boot.kernelPackages = mkOverride 0 pkgs.linuxPackages_testing_bcachefs.kernel.version;
-
     boot.supportedFilesystems = ["bcachefs"];
     environment.systemPackages = [pkgs.bcachefs-tools];
   };


### PR DESCRIPTION
Enable upstream bcachefs support.
